### PR TITLE
fix: Always sync submodules before updating them

### DIFF
--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -392,6 +392,7 @@ func! s:make_sync_command(bang, bundle) abort
                   \ 'git remote set-url origin ' . vundle#installer#shellesc(a:bundle.uri),
                   \ 'git fetch',
                   \ 'git reset --hard origin/HEAD',
+                  \ 'git submodule sync --recursive',
                   \ 'git submodule update --init --recursive',
                   \ ]
       let cmd = join(cmd_parts, ' && ')
@@ -408,6 +409,7 @@ func! s:make_sync_command(bang, bundle) abort
     let cmd_parts = [
                 \ 'cd '.vundle#installer#shellesc(a:bundle.path()),
                 \ 'git pull',
+                \ 'git submodule sync --recursive',
                 \ 'git submodule update --init --recursive',
                 \ ]
     let cmd = join(cmd_parts, ' && ')


### PR DESCRIPTION
This ensures the origin in `.git/config` matches the one in `.gitmodules`.  Git will quite appropriately refrain from doing this automatically, because it never allows remote repositories to update local config.  You have to ask.

(See: https://stackoverflow.com/a/45679261)

In Vundle's case, it is always correct to sync.  These aren't repos that a developer maintains; they are effectively read-only copies of remote state.  Since syncing is always correct, and git won't sync unless we ask, then we should always sync.

Fixes VundleVim/Vundle.VIm#911.

---

Authored by @chiphogg, here: https://github.com/VundleVim/Vundle.vim/pull/912.