### PR TITLE
Trim trailing whitespace at logging time

### DIFF
--- a/autoload/vundle.vim
+++ b/autoload/vundle.vim
@@ -87,4 +87,14 @@ let vundle#lazy_load = 0
 let vundle#log = []
 let vundle#updated_bundles = []
 
+if !exists('g:vundle#git_executable')
+  let vundle#git_executable = 'git'
+endf
+if !exists('g:vundle#curl_executable')
+  let vundle#curl_executable = 'curl'
+endf
+if !exists('g:vundle#wget_executable')
+  let vundle#wget_executable = 'wget'
+endf
+
 " vim: set expandtab sts=2 ts=2 sw=2 tw=78 norl:

--- a/autoload/vundle.vim
+++ b/autoload/vundle.vim
@@ -89,12 +89,12 @@ let vundle#updated_bundles = []
 
 if !exists('g:vundle#git_executable')
   let vundle#git_executable = 'git'
-endf
+endif
 if !exists('g:vundle#curl_executable')
   let vundle#curl_executable = 'curl'
-endf
+endif
 if !exists('g:vundle#wget_executable')
   let vundle#wget_executable = 'wget'
-endf
+endif
 
 " vim: set expandtab sts=2 ts=2 sw=2 tw=78 norl:

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -527,8 +527,11 @@ func! s:log(str, ...) abort
   let fmt = '%Y-%m-%d %H:%M:%S'
   let lines = split(a:str, '\n', 1)
   let time = strftime(fmt)
+  let entry_prefix = '['. time .'] '. prefix
   for line in lines
-      call add(g:vundle#log, '['. time .'] '. prefix . line)
+    " Trim trailing whitespace
+    let entry = substitute(entry_prefix . line, '\m\s\+$', '', '')
+    call add(g:vundle#log, entry)
   endfor
   return a:str
 endf

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -343,7 +343,8 @@ endf
 " return -- the URL for the origin remote (string)
 " ---------------------------------------------------------------------------
 func! s:get_current_origin_url(bundle) abort
-  let cmd = 'cd '.vundle#installer#shellesc(a:bundle.path()).' && git config --get remote.origin.url'
+  let cmd = 'cd '.vundle#installer#shellesc(a:bundle.path()).' && '.
+    g:vundle#git_executable.' config --get remote.origin.url'
   let cmd = vundle#installer#shellesc_cd(cmd)
   let out = s:strip(s:system(cmd))
   return out
@@ -357,7 +358,8 @@ endf
 " return -- A 15 character log sha for the current HEAD
 " ---------------------------------------------------------------------------
 func! s:get_current_sha(bundle)
-  let cmd = 'cd '.vundle#installer#shellesc(a:bundle.path()).' && git rev-parse HEAD'
+  let cmd = 'cd '.vundle#installer#shellesc(a:bundle.path()).' && '.
+    g:vundle#git_executable.' rev-parse HEAD'
   let cmd = vundle#installer#shellesc_cd(cmd)
   let out = s:system(cmd)[0:15]
   return out
@@ -389,10 +391,10 @@ func! s:make_sync_command(bang, bundle) abort
       " Directory names match but the origin remotes are not the same
       let cmd_parts = [
                   \ 'cd '.vundle#installer#shellesc(a:bundle.path()) ,
-                  \ 'git remote set-url origin ' . vundle#installer#shellesc(a:bundle.uri),
-                  \ 'git fetch',
-                  \ 'git reset --hard origin/HEAD',
-                  \ 'git submodule update --init --recursive',
+                  \ g:vundle#git_executable.' remote set-url origin ' . vundle#installer#shellesc(a:bundle.uri),
+                  \ g:vundle#git_executable.' fetch',
+                  \ g:vundle#git_executable.' reset --hard origin/HEAD',
+                  \ g:vundle#git_executable.' submodule update --init --recursive',
                   \ ]
       let cmd = join(cmd_parts, ' && ')
       let cmd = vundle#installer#shellesc_cd(cmd)
@@ -407,15 +409,15 @@ func! s:make_sync_command(bang, bundle) abort
 
     let cmd_parts = [
                 \ 'cd '.vundle#installer#shellesc(a:bundle.path()),
-                \ 'git pull',
-                \ 'git submodule update --init --recursive',
+                \ g:vundle#git_executable.' pull',
+                \ g:vundle#git_executable.' submodule update --init --recursive',
                 \ ]
     let cmd = join(cmd_parts, ' && ')
     let cmd = vundle#installer#shellesc_cd(cmd)
 
     let initial_sha = s:get_current_sha(a:bundle)
   else
-    let cmd = 'git clone --recursive '.vundle#installer#shellesc(a:bundle.uri).' '.vundle#installer#shellesc(a:bundle.path())
+    let cmd = g:vundle#git_executable.' clone --recursive '.vundle#installer#shellesc(a:bundle.uri).' '.vundle#installer#shellesc(a:bundle.path())
     let initial_sha = ''
   endif
   return [cmd, initial_sha]

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -356,7 +356,7 @@ endf
 " return -- A 15 character log sha for the current HEAD
 " ---------------------------------------------------------------------------
 func! s:get_current_sha(bundle)
-  let cmd = s:make_sync_command(a:bundle, ['rev-parse', 'HEAD'])
+  let cmd = s:make_git_command(a:bundle, ['rev-parse', 'HEAD'])
   let out = s:system(cmd)[0:15]
   return out
 endf
@@ -374,7 +374,7 @@ func! s:make_git_command(bundle, args) abort
 
   let git = ['git', '--git-dir='.gitdir, '--work-tree='.workdir]
 
-  return join(map(copy(git + args), 'vundle#installer#shellesc'))
+  return join(map(git + a:args, 'vundle#installer#shellesc(v:val)'))
 endf
 
 " ---------------------------------------------------------------------------
@@ -385,7 +385,7 @@ endf
 " return -- A string containing the escaped shell command
 " ---------------------------------------------------------------------------
 func! s:make_git_commands(bundle, argss) abort
-  return join(map(a:argss, 's:make_git_command(s:bundle, {})'), ' && ')
+  return join(map(a:argss, 's:make_git_command(a:bundle, v:val)'), ' && ')
 endf
 
 " ---------------------------------------------------------------------------
@@ -412,11 +412,11 @@ func! s:make_sync_command(bang, bundle) abort
       call s:log('>  Plugin ' . a:bundle.name . ' new URI: ' . a:bundle.uri)
       " Directory names match but the origin remotes are not the same
       let cmd_parts = [
-          [ 'remote', 'set-url', 'origin', a:bundle.uri ],
-          [ 'fetch' ],
-          [ 'reset', '--hard', 'origin/HEAD' ],
-          [ 'submodule', 'update', '--init', '--recursive' ],
-        ]
+        \  [ 'remote', 'set-url', 'origin', a:bundle.uri ],
+        \  [ 'fetch' ],
+        \  [ 'reset', '--hard', 'origin/HEAD' ],
+        \  [ 'submodule', 'update', '--init', '--recursive' ]
+        \]
       let cmd = s:make_git_commands(a:bundle, cmd_parts)
       let initial_sha = ''
       return [cmd, initial_sha]

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -372,9 +372,12 @@ func! s:make_git_command(bundle, args) abort
   let workdir = a:bundle.path()
   let gitdir  = workdir.'/.git/'
 
-  let git = [g:vundle#git_executable, '--git-dir='.gitdir, '--work-tree='.workdir]
+  let git_cmd = [g:vundle#git_executable, '--git-dir', gitdir]
+  if a:args[0] != 'clone'
+    let git_cmd = git_cmd + ['-C', workdir, '--work-tree', workdir]
+  endif
 
-  return join(map(git + a:args, 'vundle#installer#shellesc(v:val)'))
+  return join(map(git_cmd + a:args, 'vundle#installer#shellesc(v:val)'))
 endf
 
 " ---------------------------------------------------------------------------

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -76,6 +76,38 @@ endf
 
 
 " ---------------------------------------------------------------------------
+" Parse the output from git log after an update to create a change log for the
+" user.
+" ---------------------------------------------------------------------------
+func! vundle#installer#create_changelog() abort
+  let changelog = ['Updated Plugins:']
+  for bundle_data in g:vundle#updated_bundles
+    let initial_sha = bundle_data[0]
+    let updated_sha = bundle_data[1]
+    let bundle      = bundle_data[2]
+
+    let cmd = s:make_git_command(bundle, ['log', '--pretty=format:%s   %an, %ar',
+                    \                     '--graph', initial_sha.'..'.updated_sha ])
+
+    let updates = system(cmd)
+
+    call add(changelog, '')
+    call add(changelog, 'Updated Plugin: '.bundle.name)
+
+    if bundle.uri =~ "https://github.com"
+      call add(changelog, 'Compare at: '.bundle.uri[0:-5].'/compare/'.initial_sha.'...'.updated_sha)
+    endif
+
+    for update in split(updates, '\n')
+      let update = substitute(update, '\s\+$', '', '')
+      call add(changelog, '  '.update)
+    endfor
+  endfor
+  return changelog
+endf
+
+
+" ---------------------------------------------------------------------------
 " Call another function in the different Vundle windows.
 "
 " func_name -- the function to call

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -428,16 +428,13 @@ func! s:make_sync_command(bang, bundle) abort
     endif
 
     let cmd_parts = [
-                \ 'cd '.vundle#installer#shellesc(a:bundle.path()),
-                \ g:vundle#git_executable.' pull',
-                \ g:vundle#git_executable.' submodule update --init --recursive',
-                \ ]
-    let cmd = join(cmd_parts, ' && ')
-    let cmd = vundle#installer#shellesc_cd(cmd)
-
+          \  [ 'pull'],
+          \  [ 'submodule', 'update', '--init', '--recursive']
+          \]
+    let cmd = s:make_git_commands(a:bundle, cmd_parts)
     let initial_sha = s:get_current_sha(a:bundle)
   else
-    let cmd = g:vundle#git_executable.' clone --recursive '.vundle#installer#shellesc(a:bundle.uri).' '.vundle#installer#shellesc(a:bundle.path())
+    let cmd = s:make_git_command(a:bundle, ['clone', '--recursive', a:bundle.uri, a:bundle.path()])
     let initial_sha = ''
   endif
   return [cmd, initial_sha]

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -343,8 +343,7 @@ endf
 " return -- the URL for the origin remote (string)
 " ---------------------------------------------------------------------------
 func! s:get_current_origin_url(bundle) abort
-  let cmd = 'cd '.vundle#installer#shellesc(a:bundle.path()).' && git config --get remote.origin.url'
-  let cmd = vundle#installer#shellesc_cd(cmd)
+  let cmd = s:make_git_command(a:bundle, ['config', '--get', 'remote.origin.url'])
   let out = s:strip(s:system(cmd))
   return out
 endf
@@ -357,12 +356,37 @@ endf
 " return -- A 15 character log sha for the current HEAD
 " ---------------------------------------------------------------------------
 func! s:get_current_sha(bundle)
-  let cmd = 'cd '.vundle#installer#shellesc(a:bundle.path()).' && git rev-parse HEAD'
-  let cmd = vundle#installer#shellesc_cd(cmd)
+  let cmd = s:make_sync_command(a:bundle, ['rev-parse', 'HEAD'])
   let out = s:system(cmd)[0:15]
   return out
 endf
 
+" ---------------------------------------------------------------------------
+" Build a safe (escaped) git command
+"
+" bundle -- A bundle object to get the path to the git dir
+" args   -- A list of arguments to the git executable
+" return -- A string containing the escaped shell command
+" ---------------------------------------------------------------------------
+func! s:make_git_command(bundle, args) abort
+  let workdir = a:bundle.path()
+  let gitdir  = workdir.'/.git/'
+
+  let git = ['git', '--git-dir='.gitdir, '--work-tree='.workdir]
+
+  return join(map(copy(git + args), 'vundle#installer#shellesc'))
+endf
+
+" ---------------------------------------------------------------------------
+" Build a safe (escaped) command from list of git args
+"
+" bundle -- A bundle object to get the path to the git dir
+" argss  -- A list of lists of arguments to successive git calls
+" return -- A string containing the escaped shell command
+" ---------------------------------------------------------------------------
+func! s:make_git_commands(bundle, argss) abort
+  return join(map(a:argss, 's:make_git_command(s:bundle, {})'), ' && ')
+endf
 
 " ---------------------------------------------------------------------------
 " Create the appropriate sync command to run according to the current state of
@@ -388,14 +412,12 @@ func! s:make_sync_command(bang, bundle) abort
       call s:log('>  Plugin ' . a:bundle.name . ' new URI: ' . a:bundle.uri)
       " Directory names match but the origin remotes are not the same
       let cmd_parts = [
-                  \ 'cd '.vundle#installer#shellesc(a:bundle.path()) ,
-                  \ 'git remote set-url origin ' . vundle#installer#shellesc(a:bundle.uri),
-                  \ 'git fetch',
-                  \ 'git reset --hard origin/HEAD',
-                  \ 'git submodule update --init --recursive',
-                  \ ]
-      let cmd = join(cmd_parts, ' && ')
-      let cmd = vundle#installer#shellesc_cd(cmd)
+          [ 'remote', 'set-url', 'origin', a:bundle.uri ],
+          [ 'fetch' ],
+          [ 'reset', '--hard', 'origin/HEAD' ],
+          [ 'submodule', 'update', '--init', '--recursive' ],
+        ]
+      let cmd = s:make_git_commands(a:bundle, cmd_parts)
       let initial_sha = ''
       return [cmd, initial_sha]
     endif

--- a/autoload/vundle/scripts.vim
+++ b/autoload/vundle/scripts.vim
@@ -83,11 +83,8 @@ func! s:create_changelog() abort
     let updated_sha = bundle_data[1]
     let bundle      = bundle_data[2]
 
-    let cmd = 'cd '.vundle#installer#shellesc(bundle.path()).
-          \              ' && git log --pretty=format:"%s   %an, %ar" --graph '.
-          \               initial_sha.'..'.updated_sha
-
-    let cmd = vundle#installer#shellesc_cd(cmd)
+    let cmd = s:make_git_command(bundle, ['log', '--pretty=format:"%s   %an, %ar"',
+                    \                     '--graph', initial_sha.'..'.updated_sha ])
 
     let updates = system(cmd)
 

--- a/autoload/vundle/scripts.vim
+++ b/autoload/vundle/scripts.vim
@@ -84,7 +84,7 @@ func! s:create_changelog() abort
     let bundle      = bundle_data[2]
 
     let cmd = 'cd '.vundle#installer#shellesc(bundle.path()).
-          \              ' && git log --pretty=format:"%s   %an, %ar" --graph '.
+          \              ' && '.g:vundle#git_executable.' log --pretty=format:"%s   %an, %ar" --graph '.
           \               initial_sha.'..'.updated_sha
 
     let cmd = vundle#installer#shellesc_cd(cmd)
@@ -235,11 +235,11 @@ func! s:fetch_scripts(to)
   endif
 
   let l:vim_scripts_json = 'http://vim-scripts.org/api/scripts.json'
-  if executable("curl")
-    let cmd = 'curl --fail -s -o '.vundle#installer#shellesc(a:to).' '.l:vim_scripts_json
-  elseif executable("wget")
+  if executable(g:vundle#curl_executable)
+    let cmd = g:vundle#curl_executable.' --fail -s -o '.vundle#installer#shellesc(a:to).' '.l:vim_scripts_json
+  elseif executable(g:vundle#wget_executable)
     let temp = vundle#installer#shellesc(tempname())
-    let cmd = 'wget -q -O '.temp.' '.l:vim_scripts_json. ' && mv -f '.temp.' '.vundle#installer#shellesc(a:to)
+    let cmd = g:vundle#wget_executable.' -q -O '.temp.' '.l:vim_scripts_json. ' && mv -f '.temp.' '.vundle#installer#shellesc(a:to)
     if (has('win32') || has('win64'))
       let cmd = substitute(cmd, 'mv -f ', 'move /Y ', '') " change force flag
       let cmd = vundle#installer#shellesc(cmd)

--- a/autoload/vundle/scripts.vim
+++ b/autoload/vundle/scripts.vim
@@ -67,6 +67,7 @@ func! s:view_log()
   setl buftype=nofile
   setl noswapfile
   setl ro noma
+  setfiletype vundlelog
 
   wincmd P | wincmd H
 endf
@@ -124,7 +125,7 @@ func! s:view_changelog()
   setl buftype=nofile
   setl noswapfile
   setl ro noma
-  setfiletype vundlelog
+  setfiletype vundlechangelog
 
   wincmd P | wincmd H
 endf

--- a/autoload/vundle/scripts.vim
+++ b/autoload/vundle/scripts.vim
@@ -74,38 +74,6 @@ endf
 
 
 " ---------------------------------------------------------------------------
-" Parse the output from git log after an update to create a change log for the
-" user.
-" ---------------------------------------------------------------------------
-func! s:create_changelog() abort
-  let changelog = ['Updated Plugins:']
-  for bundle_data in g:vundle#updated_bundles
-    let initial_sha = bundle_data[0]
-    let updated_sha = bundle_data[1]
-    let bundle      = bundle_data[2]
-
-    let cmd = s:make_git_command(bundle, ['log', '--pretty=format:"%s   %an, %ar"',
-                    \                     '--graph', initial_sha.'..'.updated_sha ])
-
-    let updates = system(cmd)
-
-    call add(changelog, '')
-    call add(changelog, 'Updated Plugin: '.bundle.name)
-
-    if bundle.uri =~ "https://github.com"
-      call add(changelog, 'Compare at: '.bundle.uri[0:-5].'/compare/'.initial_sha.'...'.updated_sha)
-    endif
-
-    for update in split(updates, '\n')
-      let update = substitute(update, '\s\+$', '', '')
-      call add(changelog, '  '.update)
-    endfor
-  endfor
-  return changelog
-endf
-
-
-" ---------------------------------------------------------------------------
 " View the change log after an update or installation.
 " ---------------------------------------------------------------------------
 func! s:view_changelog()
@@ -116,7 +84,7 @@ func! s:view_changelog()
   if bufloaded(s:changelog_file)
     execute 'silent bdelete' s:changelog_file
   endif
-  call writefile(s:create_changelog(), s:changelog_file)
+  call writefile(vundle#installer#create_changelog(), s:changelog_file)
   execute 'silent pedit' s:changelog_file
   set bufhidden=wipe
   setl buftype=nofile

--- a/ftplugin/vundlechangelog.vim
+++ b/ftplugin/vundlechangelog.vim
@@ -8,7 +8,8 @@ let b:did_ftplugin = 1
 
 
 " ---------------------------------------------------------------------------
-" Settings for the Vundle log buffer.
+" Settings for the Vundle update log buffer.
 " ---------------------------------------------------------------------------
 setlocal textwidth=0
+setlocal nowrap
 setlocal noswapfile

--- a/syntax/vundlechangelog.vim
+++ b/syntax/vundlechangelog.vim
@@ -1,0 +1,36 @@
+" ---------------------------------------------------------------------------
+" Syntax highlighting for the line which identifies the plugin.
+" ---------------------------------------------------------------------------
+syntax match VundlePluginName '\v(^Updated Plugin: )@<=.*$'
+highlight link VundlePluginName Keyword
+
+" ---------------------------------------------------------------------------
+" Syntax highlighting for the 'compare at' line of each plugin.
+" ---------------------------------------------------------------------------
+syntax region VundleCompareLine start='\v^Compare at: https:' end='\v\n'
+    \ contains=VundleCompareUrl
+syntax match VundleCompareUrl '\vhttps:\S+'
+highlight link VundleCompareLine Comment
+highlight link VundleCompareUrl Underlined
+
+" ---------------------------------------------------------------------------
+" Syntax highlighting for individual commits.
+" ---------------------------------------------------------------------------
+" The main commit line.
+" Note that this regex is intimately related to the one for VundleCommitTree,
+" and the two should be changed in sync.
+syntax match VundleCommitLine '\v(^  [|*]( *[\\|/\*])* )@<=[^*|].*$'
+    \ contains=VundleCommitMerge,VundleCommitUser,VundleCommitTime
+highlight link VundleCommitLine String
+" Sub-regions inside the commit message.
+syntax match VundleCommitMerge '\v Merge pull request #\d+.*'
+syntax match VundleCommitUser '\v(   )@<=\S+( \S+)*(, \d+ \w+ ago$)@='
+syntax match VundleCommitTime '\v(, )@<=\d+ \w+ ago$'
+highlight link VundleCommitMerge Ignore
+highlight link VundleCommitUser Identifier
+highlight link VundleCommitTime Comment
+" The git history DAG markers are outside of the main commit line region.
+" Note that this regex is intimately related to the one for VundleCommitLine,
+" and the two should be changed in sync.
+syntax match VundleCommitTree '\v(^  )@<=[|*]( *[\\|/\*])*'
+highlight link VundleCommitTree Label

--- a/syntax/vundlelog.vim
+++ b/syntax/vundlelog.vim
@@ -1,36 +1,42 @@
 " ---------------------------------------------------------------------------
 " Syntax highlighting for the line which identifies the plugin.
 " ---------------------------------------------------------------------------
-syntax match VundlePluginName '\v(^Updated Plugin: )@<=.*$'
+syntax match VundlePluginName '\v\C(Plugin )@<=\S+/\S+(\s|$)'
 highlight link VundlePluginName Keyword
 
 " ---------------------------------------------------------------------------
-" Syntax highlighting for the 'compare at' line of each plugin.
+" Syntax highlighting for diffs on each plugin
 " ---------------------------------------------------------------------------
-syntax region VundleCompareLine start='\v^Compare at: https:' end='\v\n'
-    \ contains=VundleCompareUrl
-syntax match VundleCompareUrl '\vhttps:\S+'
-highlight link VundleCompareLine Comment
-highlight link VundleCompareUrl Underlined
+syntax match VundleGitAddition '\v(\|\s*\d+ )@<=\++'
+highlight VundleGitAddition guifg=darkgreen guibg=NONE gui=bold
+    \ ctermfg=darkgreen ctermbg=NONE cterm=bold
+
+syntax match VundleGitDeletion '\v(\|\s*\d+ \+*)@<=-+'
+highlight VundleGitDeletion guifg=red guibg=NONE gui=bold ctermfg=red
+    \ ctermbg=NONE cterm=bold
 
 " ---------------------------------------------------------------------------
-" Syntax highlighting for individual commits.
+" Syntax highlighting for log-specific features
 " ---------------------------------------------------------------------------
-" The main commit line.
-" Note that this regex is intimately related to the one for VundleCommitTree,
-" and the two should be changed in sync.
-syntax match VundleCommitLine '\v(^  [|*]( *[\\|/\*])* )@<=[^*|].*$'
-    \ contains=VundleCommitMerge,VundleCommitUser,VundleCommitTime
-highlight link VundleCommitLine String
-" Sub-regions inside the commit message.
-syntax match VundleCommitMerge '\v Merge pull request #\d+.*'
-syntax match VundleCommitUser '\v(   )@<=\S+( \S+)*(, \d+ \w+ ago$)@='
-syntax match VundleCommitTime '\v(, )@<=\d+ \w+ ago$'
-highlight link VundleCommitMerge Ignore
-highlight link VundleCommitUser Identifier
-highlight link VundleCommitTime Comment
-" The git history DAG markers are outside of the main commit line region.
-" Note that this regex is intimately related to the one for VundleCommitLine,
-" and the two should be changed in sync.
-syntax match VundleCommitTree '\v(^  )@<=[|*]( *[\\|/\*])*'
-highlight link VundleCommitTree Label
+syntax match VundleCaret '\V >'
+highlight link VundleCaret Label
+
+" Make path to tags file stand out
+syntax match VundleTagPath '\v\C(:helptags )@<=/\S+$'
+highlight link VundleTagPath Comment
+
+" Make URL stand out
+syntax match VundleCompareUrl '\v\Chttps:\S+'
+highlight link VundleCompareUrl Underlined
+
+" Make errors (from git) stand out
+syntax match VundleError '\v\C( \> )@<=fatal:.*$'
+highlight link VundleError Error
+
+" Make git messages stand out
+syntax match VundleGitMsg '\v\C( \> )@<=git:.*$'
+highlight link VundleGitMsg Type
+
+" De-emphasize the time stamp
+syntax match VundleTimeStamp '\m^\[\d\{4}-\d\{2}-\d\{2} \d\{2}:\d\{2}:\d\{2}]'
+highlight link VundleTimeStamp String


### PR DESCRIPTION
I tested the current release, and it breaks at update time and for changelog generation.

The issue is that you need to be in the git_dir for git to work correctly for submodules, but that you cannot move to the worktree when cloning (because it does not exist yet).

The changelog was broken because make_git_command was not available in that script.
I moved one function around and exported it.

---

Authored by @layus, here: https://github.com/VundleVim/Vundle.vim/pull/790.